### PR TITLE
Fix Ubuntu Compile

### DIFF
--- a/include/cli/detail/linuxkeyboard.h
+++ b/include/cli/detail/linuxkeyboard.h
@@ -52,7 +52,7 @@ namespace detail
 class LinuxKeyboard : public InputDevice
 {
 public:
-    explicit LinuxKeyboard(asio::BoostExecutor ex) :
+    explicit LinuxKeyboard(cli::detail::notboost::BoostExecutor ex):
         InputDevice(ex)
     {
         ToManualMode();

--- a/include/cli/remotecli.h
+++ b/include/cli/remotecli.h
@@ -30,7 +30,7 @@
 #ifndef CLI_REMOTECLI_H_
 #define CLI_REMOTECLI_H_
 
-#include <cli/detail/inputhandler.h>
+#include "detail/inputhandler.h"
 #include <memory>
 #include "cli.h"
 #include "detail/server.h"


### PR DESCRIPTION
Adjust to local includes as well to use the linux, but the keyboard handler is not working properly.
Ctrl-C does not work - but it might be a feature not a bug ;)